### PR TITLE
Unify duplicated `execa` specification and update its version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
     "redirected"
   ],
   "dependencies": {
-    "execa": "^0.6.3"
+    "execa": "^0.7.0"
   },
   "devDependencies": {
     "ava": "*",
-    "execa": "^0.6.3",
     "xo": "*"
   }
 }


### PR DESCRIPTION
Currently `"execa": "^0.6.3"` exists on both [`dependencies`](https://github.com/sindresorhus/term-size/blob/ed9b5cacd1890e0a5082cd3c847504fb035c78f9/package.json#L37) and [`devDependencies`](https://github.com/sindresorhus/term-size/blob/ed9b5cacd1890e0a5082cd3c847504fb035c78f9/package.json#L41).
