### PR TITLE
Update execa from 0.7.x to 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "redirected"
   ],
   "dependencies": {
-    "execa": "^0.7.0"
+    "execa": "^0.8.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
https://github.com/sindresorhus/execa/compare/v0.7.0...v0.8.0

Nothing affects term-size, but this update helps better deduplication for the project using the latest `execa`.
