### PR TITLE
Fix bug where execFileSync returned Uint8Array instead of String

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const {execFileSync} = require('child_process');
 const path = require('path');
 
-const exec = (command, arguments_, shell) => execFileSync(command, arguments_, {encoding: 'utf8', shell}).trim();
+const exec = (command, arguments_, shell) => execFileSync(command, arguments_, {encoding: 'utf8', shell}).toString().trim();
 
 const create = (columns, rows) => ({
 	columns: parseInt(columns, 10),


### PR DESCRIPTION
I'm using [`cmder`](https://cmder.net/) (/ConEmu) on Windows 10, and `child_process.execFileSync` is returning an `Uint8Array` instead of a `String`. Resulting in a fixed console width of 80 columns; the fallback width, as the array doesn't have a `trim` method.

Fixed this by forcing the response to become a string, before calling the `trim` method. 