### PR TITLE
Ignore stderr on spawned processes

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const exec = (command, arguments_, shell) => execFileSync(command, arguments_, {encoding: 'utf8', shell}).trim();
+const exec = (command, arguments_, shell) =>
+	execFileSync(command, arguments_, {encoding: 'utf8', shell, stdio: ['pipe', 'pipe', 'ignore']}).trim();
 
 const create = (columns, rows) => ({
 	columns: Number.parseInt(columns, 10),


### PR DESCRIPTION
When using term-info on a non-interactive terminal (like in CI or a pre-commit hook in Sublime Merge), resize and tput write out to stderr:

```
Opening `/dev/tty` failed (6): Device not configured
resize:  can't open terminal /dev/tty
tput: No value for $TERM and no -T specified
```

We can suppress these by passing `'ignore'` for the third tuple value of `stdio`, which corresponds to `stderr`.