### PR TITLE
Do not construct dirname on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,13 @@ import {execFileSync} from 'node:child_process';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 const exec = (command, arguments_, shell) =>
 	execFileSync(command, arguments_, {encoding: 'utf8', shell, stdio: ['ignore', 'pipe', 'ignore']}).trim();
+
+function execNative(command, shell) {
+	const __dirname = path.dirname(fileURLToPath(import.meta.url));
+	return exec(path.join(__dirname, command), [], shell).split(/\r?\n/);
+}
 
 const create = (columns, rows) => ({
 	columns: Number.parseInt(columns, 10),
@@ -32,7 +35,7 @@ export default function terminalSize() {
 	if (process.platform === 'win32') {
 		try {
 			// Binary: https://github.com/sindresorhus/win-term-size
-			const size = exec(path.join(__dirname, 'vendor/windows/term-size.exe')).split(/\r?\n/);
+			const size = execNative('vendor/windows/term-size.exe', false);
 
 			if (size.length === 2) {
 				return create(size[0], size[1]);
@@ -42,7 +45,7 @@ export default function terminalSize() {
 		if (process.platform === 'darwin') {
 			try {
 				// Binary: https://github.com/sindresorhus/macos-term-size
-				const size = exec(path.join(__dirname, 'vendor/macos/term-size'), [], true).split(/\r?\n/);
+				const size = execNative('vendor/macos/term-size', true);
 
 				if (size.length === 2) {
 					return create(size[0], size[1]);


### PR DESCRIPTION
I'm bundling term-size using esbuild, which handles `import.meta.url` a bit [differently](https://github.com/evanw/esbuild/issues/1492#issuecomment-893144483) than other bundlers.

Now, in my case, the `fileURLToPath` call is dead code, because I'm running my bundle on Linux, where term-size doesn't need to invoke any commands. So I was thinking it could be more lazy, and coincidentally fix the issue I'm facing.

This PR moves the `__dirname` emulation into a helper function that's only called on macOS and Windows.

I've also put the line-splitting in there because I prefer DRY code, but it's a bit esoteric this way. Would you prefer an explicit `splitLines` (or even a dependency on `split-lines`)? Or alternatively, I could make a less invasive PR and only extract the `__dirname` construction into a helper function, for example.

... Or we could find a better way to deal with the lack of `__dirname` in ESM. 😉 